### PR TITLE
Fixes for ambiguous constructors

### DIFF
--- a/src/lang/flybytes/internal/ASTgen.rsc
+++ b/src/lang/flybytes/internal/ASTgen.rsc
@@ -99,7 +99,6 @@ str type2FactoryCall(Symbol t){
       case Symbol::\map(label(l1,ti),label(l2, ti2)) : return "tf.mapType(<type2FactoryCall(ti)>,\"<l1>\", <type2FactoryCall(ti2)>, \"<l2>\")";
       case Symbol::\map(ti,ti2) : return "tf.mapType(<type2FactoryCall(ti)>,<type2FactoryCall(ti2)>)";
       case Symbol::\tuple(tis) : return "tf.tupleType(<typeList2FactoryVarArgs(tis)>)";
-      case Symbol::\rel(tis) : return "tf.relType(<typeList2FactoryVarArgs(tis)>)";
       case Symbol::\adt(str name, _) : return "_<name>";
       default: 
         throw "Do not now how to construct <t>";  
@@ -194,7 +193,6 @@ str type2FactoryCall(Symbol t){
       case \bool() : return "IBool";
       case \list(_) : return "IList";
       case \map(_,_) : return "IMap";
-      case \rel(_) : return "IRelation";
       case \set(_) : return "ISet";
       case \loc() : return "ISourceLocation";
       case \str() :  return "IString";

--- a/src/lang/flybytes/tests/ArrayTests.rsc
+++ b/src/lang/flybytes/tests/ArrayTests.rsc
@@ -40,9 +40,9 @@ Exp defVal(long()) = jconst(0);
 Exp defVal(byte()) = bconst(0);
 Exp defVal(character()) = cconst(0);
 Exp defVal(short()) = sconst(0);
-Exp defVal(object(str _)) = null();
-Exp defVal(array(Type _)) = null();
-Exp defVal(string()) = null();
+Exp defVal(object(str _)) = Exp::null();
+Exp defVal(array(Type _)) = Exp::null();
+Exp defVal(string()) = Exp::null();
 Exp defVal(boolean()) = \false();
 
 list[Type] primTypes = [integer(), short(), byte(), character(), long()];


### PR DESCRIPTION
Fixes for the following errors:
error(
      "Undefined constructor `\\rel`",
      |file:///Users/paulklint/git/flybytes/src/lang/flybytes/internal/ASTgen.rsc|(10047,4,<197,11>,<197,15>),
      fixes=[]),
    error(
      "Undefined constructor `Symbol::\\rel`",
      |file:///Users/paulklint/git/flybytes/src/lang/flybytes/internal/ASTgen.rsc|(6407,12,<102,11>,<102,23>),
      fixes=[])
  ])

   error(
      "Constructor `null` is overloaded, maybe you may use Exp or Mirror as qualifier  or make argument type(s) more precise",
      |file:///Users/paulklint/git/flybytes/src/lang/flybytes/tests/ArrayTests.rsc|(1385,6,<44,28>,<44,34>),
      fixes=[]),
    error(
      "Constructor `null` is overloaded, maybe you may use Exp or Mirror as qualifier  or make argument type(s) more precise",
      |file:///Users/paulklint/git/flybytes/src/lang/flybytes/tests/ArrayTests.rsc|(1349,6,<43,28>,<43,34>),
      fixes=[]),
    error(
      "Constructor `null` is overloaded, maybe you may use Exp or Mirror as qualifier  or make argument type(s) more precise",
      |file:///Users/paulklint/git/flybytes/src/lang/flybytes/tests/ArrayTests.rsc|(1416,6,<45,23>,<45,29>),
      fixes=[]),
    warning(
      "Unused formal `val`",
      |file:///Users/paulklint/git/flybytes/src/lang/flybytes/tests/ArrayTests.rsc|(3424,3,<105,55>,<105,58>))
  ])